### PR TITLE
Fixed bug relating to hitting enter after dividing by 0 & updated del…

### DIFF
--- a/script.js
+++ b/script.js
@@ -271,9 +271,15 @@ function equalBtnClicked(e) {
     // click =
     // 5+2 = 7
     else if (secondToLastOperator == '=' || secondToLastOperator == 'Enter') {
-        displayNumberOne.textContent = `${previousTotal}`
-        displayOperator.textContent = `${lastOperatorThatIsNotEqualOrDelete}`
-        displayTotal.textContent = `= ${total}`
+        // used when dividing by 0 and then clicking enter on keyboard (= btn is disabled so do not need to worry about that)
+        // this prevents an output of 0/=0
+        if(lastOperator == 'Enter' && number2 == 0 && lastOperatorThatIsNotEqualOrDelete == '/') {
+            return
+        } else {
+            displayNumberOne.textContent = `${previousTotal}`
+            displayOperator.textContent = `${lastOperatorThatIsNotEqualOrDelete}`
+            displayTotal.textContent = `= ${total}`
+        }
     }
     // used for scenarios of 1+2-=
     else if (secondToLastOperator == '-' || secondToLastOperator == '+' || secondToLastOperator == '/' || secondToLastOperator == '*') {
@@ -367,6 +373,11 @@ function deleteBtnClicked(e) {
         // clear the operator array so on next operator click undefined is passed as the operator which will NOT perform math until either = or another operator is clicked
         operatorArray = []
     }
+
+    // used in case tried to divide by 0 to get error and click delete it re-enables all operator btns and equals btn
+    operatorBtns.forEach((button) => {button.disabled = false})
+    equalsBtn.disabled = false;
+
 }
 
 deleteBtn.addEventListener('click', (e) => {


### PR DESCRIPTION
…ete btn function

When doing 4/0 the calc displays the error but if you clicked Enter on keyboard as the next click you were getting dispaly of 0/=0.  Equal btn (=) is disabled so the issue was related to enter on keyboard.  Updated logic so if the last operator clicked was enter from keyboard, number 2 is 0 and last operator clicked is / then return and stop running the function

Updated delete btn function so when clicking it will re-enable the operator & equal btns on screen